### PR TITLE
Fix logic of handling optional "On Behalf Of Organization"

### DIFF
--- a/CRM/Grant/Form/Grant/Confirm.php
+++ b/CRM/Grant/Form/Grant/Confirm.php
@@ -527,7 +527,7 @@ class CRM_Grant_Form_Grant_Confirm extends CRM_Grant_Form_GrantBase {
     }
     // If onbehalf-of-organization grant application add organization
     // and it's location.
-    if (isset($this->_values['onbehalf_profile_id']) && isset($behalfOrganization['organization_name'])) {
+    if (!empty($this->_values['onbehalf_profile_id']) && !empty($behalfOrganization['organization_name'])) {
       $ufFields = array();
       foreach ($this->_fields['onbehalf'] as $name => $value) {
         $ufFields[$name] = 1;


### PR DESCRIPTION
Correct form processing logic so that if no "On Behalf Of Organization" information is entered, it is not processed.

At the moment, the code checks for isset(), but due to the way the form data is processed above, these variables will always be set but may just be empty if no organization information is entered.

This change corrects the logic so you don't get spurious creation of blank organisations. Tested and working on CiviCRM 5.37.0.