### PR TITLE
Include 'Grant' entity custom fields in buildCustomProfile()

### DIFF
--- a/CRM/Grant/BAO/GrantApplicationPage.php
+++ b/CRM/Grant/BAO/GrantApplicationPage.php
@@ -556,10 +556,15 @@ AND module = 'CiviGrant'  AND civicrm_uf_join.is_active = 1 ) $whereClause";
     );
 
     if ($gid) {
-      if (CRM_Core_BAO_UFGroup::filterUFGroups($gid, $cid)) {
+      $profileType = CRM_Core_BAO_UFField::getProfileType($gid);
+      // Match if profile type is 'Grant' (or built-in contact types)
+      if (($profileType == 'Grant') || CRM_Core_BAO_UFGroup::filterUFGroups($gid, $cid)) {
         $values = array();
         $groupTitle = NULL;
-        $fields = CRM_Core_BAO_UFGroup::getFields($gid, FALSE, CRM_Core_Action::VIEW, NULL, NULL, FALSE, NULL, FALSE, NULL, CRM_Core_Permission::CREATE, NULL);
+        // Need to expressly include 'Grant' in entity types for custom field retrieval
+        // Use default list of entity types specified in CRM_Core_BAO_CustomField::getFields() with 'Grant'
+        $ctype = ['Contact', 'Individual', 'Organization', 'Household', 'Grant'];
+        $fields = CRM_Core_BAO_UFGroup::getFields($gid, FALSE, CRM_Core_Action::VIEW, NULL, NULL, FALSE, NULL, FALSE, $ctype, CRM_Core_Permission::CREATE, NULL);
         $fields = array_diff_key($fields, $fieldsToIgnore);
         foreach ($fields as $k => $v) {
           if (!$groupTitle) {


### PR DESCRIPTION
This PR is intended to fix https://github.com/JMAConsulting/biz.jmaconsulting.grantapplications/issues/175.

The root cause is that core does not retrieve custom data for the 'Grant' entity type by default when getting profile fields, and does not consider 'Grant' a special profile type (such as 'Participant' or 'Event') when filtering / matching a profile against the contact type.

Before
---
Custom fields created for the grant itself do not render correctly in confirmation emails.
![image](https://user-images.githubusercontent.com/72983627/143838382-4e9c0748-f6a1-465e-b958-9bd587204dd3.png)
(Note: contact custom fields are OK)

After
---
Custom fields created for the grant itself do render correctly in confirmation emails.
![image](https://user-images.githubusercontent.com/72983627/143838515-02e0d929-cde5-439e-ad08-471c5f7bdc4b.png)

Technical Details
---
Update buildCustomProfile() so that custom data for the Grant entity type is retrieved alongside contact data.

Two changes to make this work:
1. Always match if profile type is 'Grant' so that it will be processed in `CRM_Grant_BAO_GrantApplicationPage::buildCustomProfile()`
2. Explicitly define the custom data types to be considered by `CRM_Core_BAO_CustomField::getFields()`, which is ultimately called by `CRM_Core_BAO_UFGroup::getFields()`. Without defining `$ctype`, the filter defaults to contact entity types only. We now pass in a list of entity types comprising the default list with 'Grant' added.

Testing
---
Tested and working on CiviCRM 5.37.0 - see screenshots.