### PR TITLE
Guard against uninitialised arrays / array offsets

### DIFF
--- a/CRM/Grant/Form/GrantBase.php
+++ b/CRM/Grant/Form/GrantBase.php
@@ -156,8 +156,8 @@ class CRM_Grant_Form_GrantBase extends CRM_Core_Form {
 
     $this->_values = $this->get('values');
     $this->_fields = $this->get('fields');
-    $this->assign('title', $this->_values['title']);
-    CRM_Utils_System::setTitle($this->_values['title']);
+    $this->assign('title', CRM_Utils_Array::value('title', $this->_values));
+    CRM_Utils_System::setTitle(CRM_Utils_Array::value('title', $this->_values));
 
     $this->assignHomeType();
     if (!$this->_values) {
@@ -356,7 +356,7 @@ class CRM_Grant_Form_GrantBase extends CRM_Core_Form {
           // in order to add required rule after maxfilesize rule we are setting the required parameter false for 
           // bypassing the is_required parameter ONLY for file type fields, and later added again below
           $required = $field['is_required'];
-          $field['is_required'] = ($field['html_type'] == 'File') ? FALSE : $field['is_required'];
+          $field['is_required'] = (CRM_Utils_Array::value('html_type', $field) == 'File') ? FALSE : $field['is_required'];
           if ($profileContactType) {
             if (!empty($fieldTypes) && in_array($field['field_type'], $fieldTypes)) {
               CRM_Core_BAO_UFGroup::buildProfile(
@@ -383,7 +383,7 @@ class CRM_Grant_Form_GrantBase extends CRM_Core_Form {
             );
             $this->_fields[$key] = $field;
           }
-          if ($field['html_type'] == 'File') {
+          if (CRM_Utils_Array::value('html_type', $field) == 'File') {
             $uploadFileSize = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'), TRUE);
             $uploadSize = round(($uploadFileSize / (1024 * 1024)), 2);
             $this->addRule($field['name'], $field['title'] . ': ' . E::ts('File size should be less than %1 MByte(s)', [


### PR DESCRIPTION
Use `CRM_Utils_Array::value()` in place of direct array member access to prevent polluting log files with warnings and notices, which may become more serious errors in PHP 8!

Proposed fix for #188.

Tested and working on CiviCRM 5.50.4.